### PR TITLE
Fix: Input length validation and error handling

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -18,9 +18,9 @@ export const usersRoute = new Elysia()
     }
   }, {
     body: t.Object({
-      name: t.String(),
-      email: t.String({ format: 'email' }),
-      password: t.String({ minLength: 8 }),
+      name: t.String({ maxLength: 255 }),
+      email: t.String({ format: 'email', maxLength: 255 }),
+      password: t.String({ minLength: 8, maxLength: 255 }),
     }),
     detail: {
       summary: 'Register a new user',
@@ -39,8 +39,8 @@ export const usersRoute = new Elysia()
     }
   }, {
     body: t.Object({
-      email: t.String({ format: 'email' }),
-      password: t.String(),
+      email: t.String({ format: 'email', maxLength: 255 }),
+      password: t.String({ maxLength: 255 }),
     }),
     detail: {
       summary: 'Login with email and password',

--- a/src/service/users-service.ts
+++ b/src/service/users-service.ts
@@ -19,11 +19,20 @@ export async function registerUser(input: RegisterUserInput) {
   if (!input.name || input.name.trim().length === 0) {
     throw new Error('Name is required');
   }
+  if (input.name.length > 255) {
+    throw new Error('Nama terlalu panjang, maksimal 255 karakter');
+  }
   if (!input.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
     throw new Error('Valid email is required');
   }
+  if (input.email.length > 255) {
+    throw new Error('Email terlalu panjang, maksimal 255 karakter');
+  }
   if (!input.password || input.password.length < 8) {
     throw new Error('Password must be at least 8 characters');
+  }
+  if (input.password.length > 255) {
+    throw new Error('Password terlalu panjang, maksimal 255 karakter');
   }
 
   try {
@@ -48,12 +57,22 @@ export async function registerUser(input: RegisterUserInput) {
 
     const { password, ...userWithoutPassword } = newUser;
     return userWithoutPassword;
-  } catch (error) {
+  } catch (error: any) {
     console.error('Registration error:', error);
+
+    // Handle database constraint violation
+    if (error?.message?.includes('varchar') ||
+        error?.message?.includes('length') ||
+        error?.code === 'ER_DATA_TOO_LONG' ||
+        error?.message?.includes('Data too long')) {
+      throw new Error('Input terlalu panjang, maksimal 255 karakter');
+    }
+
     if (error instanceof Error && error.message.includes('Email sudah terdaftar')) {
       throw error;
     }
-    throw new Error('Failed to register user');
+
+    throw new Error('Gagal mendaftarkan user');
   }
 }
 


### PR DESCRIPTION
## Summary

Adds input length validation (max 255 characters) for name, email, and password fields in both schema validation and business logic layer.

## Changes

- **Schema validation** (src/routes/users-route.ts):
  - Added maxLength: 255 constraint for 
ame, email, and password in registration and login schemas

- **Service layer** (src/service/users-service.ts):
  - Added explicit validation checks for maximum length (255 characters) on all input fields
  - Enhanced error handling to catch database constraint violations (ER_DATA_TOO_LONG, varchar length errors)
  - Improved error messages in Indonesian for better user feedback

## Test plan

- [x] Existing tests pass
- Input validation tested for boundary cases (255 chars accepted, 256 chars rejected)
- Database constraint violations properly caught and converted to user-friendly errors