### PR TITLE
feat: Add OpenAPI documentation for all user endpoints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "simple-api",
       "dependencies": {
+        "@elysiajs/openapi": "^1.4.15",
         "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.44.4",
         "elysia": "^1.3.2",
@@ -24,6 +25,8 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@elysiajs/openapi": ["@elysiajs/openapi@1.4.15", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-HDtGIrWfFJk6UJS7qbgRmjifbSqnnRGDM3CsU/GVJkxLbEVEkNuQDf+Quh9fGbytSrJ8g4+tX9eVjshYhCH29w=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@elysiajs/openapi": "^1.4.15",
     "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.44.4",
     "elysia": "^1.3.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,39 @@
 import { Elysia } from 'elysia';
+import { openapi } from '@elysiajs/openapi';
 import { routes } from './routes';
 import { usersRoute } from './routes/users-route';
 
-const app = new Elysia()
-  .use(routes)
-  .use(usersRoute)
-  .listen(Bun.env.PORT || 3000);
+try {
+  const app = new Elysia()
+  .use(openapi({
+    documentation: {
+      info: {
+        title: 'Users API',
+        version: '1.0.0',
+        description: 'REST API for user authentication and management'
+      },
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT'
+          }
+        }
+      }
+    }
+  }))
+    .use(routes)
+    .use(usersRoute)
+    .listen(Bun.env.PORT || 3000);
 
-console.log(
-  'Server running on ' +
-    (app.server?.hostname || 'localhost') +
-    ':' +
-    (app.server?.port || 3000)
-);
+  console.log(
+    'Server running on ' +
+      (app.server?.hostname || 'localhost') +
+      ':' +
+      (app.server?.port || 3000)
+  );
+} catch (error) {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+}

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -4,7 +4,7 @@ import { bearerAuth } from './auth-middleware';
 import { db } from '../db';
 import { users } from '../db/schema';
 
-export const usersRoute = new Elysia()
+export const usersRoute = new Elysia({ tags: ['Users'] })
   .post('/api/users', async ({ body, set }: any) => {
     try {
       const user = await registerUser(body);
@@ -24,6 +24,38 @@ export const usersRoute = new Elysia()
     }),
     detail: {
       summary: 'Register a new user',
+      responses: {
+        200: {
+          description: 'User registered successfully',
+          content: {
+            'application/json': {
+              example: {
+                data: 'Success'
+              }
+            }
+          }
+        },
+        409: {
+          description: 'Email already registered',
+          content: {
+            'application/json': {
+              example: {
+                error: 'Email sudah terdaftar'
+              }
+            }
+          }
+        },
+        422: {
+          description: 'Validation error',
+          content: {
+            'application/json': {
+              example: {
+                error: 'Validation failed'
+              }
+            }
+          }
+        }
+      }
     },
   })
   .post('/api/users/login', async ({ body, set }: any) => {
@@ -44,16 +76,138 @@ export const usersRoute = new Elysia()
     }),
     detail: {
       summary: 'Login with email and password',
+      responses: {
+        200: {
+          description: 'Login successful',
+          content: {
+            'application/json': {
+              example: {
+                data: {
+                  token: 'uuid-token-string-here'
+                }
+              }
+            }
+          }
+        },
+        401: {
+          description: 'Invalid email or password',
+          content: {
+            'application/json': {
+              example: {
+                error: 'Email atau password salah'
+              }
+            }
+          }
+        },
+        422: {
+          description: 'Validation error',
+          content: {
+            'application/json': {
+              example: {
+                error: 'Validation failed'
+              }
+            }
+          }
+        }
+      }
     },
   })
   .get('/api/users', async () => {
     const allUsers = await db.select().from(users);
-    return { 
+    return {
       users: allUsers.map((u: any) => {
         const { password, ...rest } = u;
         return rest;
       })
     };
+  }, {
+    detail: {
+      summary: 'Get all users (admin endpoint)',
+      responses: {
+        200: {
+          description: 'List of all users',
+          content: {
+            'application/json': {
+              example: {
+                users: [
+                  {
+                    id: 1,
+                    name: 'John Doe',
+                    email: 'john@example.com',
+                    created_at: '2026-04-27T07:22:33.000Z'
+                  },
+                  {
+                    id: 2,
+                    name: 'Jane Smith',
+                    email: 'jane@example.com',
+                    created_at: '2026-04-27T08:15:22.000Z'
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
   })
-  .get('/api/users/current', bearerAuth(getCurrentUser))
-  .delete('/api/users/logout', bearerAuth(logoutUser));
+  .get('/api/users/current', bearerAuth(getCurrentUser), {
+    detail: {
+      summary: 'Get current authenticated user',
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: {
+          description: 'Current user data',
+          content: {
+            'application/json': {
+              example: {
+                data: {
+                  id: 1,
+                  name: 'John Doe',
+                  email: 'john@example.com',
+                  created_at: '2026-04-27T07:22:33.000Z'
+                }
+              }
+            }
+          }
+        },
+        401: {
+          description: 'Unauthorized - invalid or missing token',
+          content: {
+            'application/json': {
+              example: {
+                error: 'Unauthorized'
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+  .delete('/api/users/logout', bearerAuth(logoutUser), {
+    detail: {
+      summary: 'Logout and delete session',
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: {
+          description: 'Logout successful',
+          content: {
+            'application/json': {
+              example: {
+                data: 'OK'
+              }
+            }
+          }
+        },
+        401: {
+          description: 'Unauthorized - invalid or missing token',
+          content: {
+            'application/json': {
+              example: {
+                error: 'Unauthorized'
+              }
+            }
+          }
+        }
+      }
+    }
+  });


### PR DESCRIPTION
## Summary

Adds comprehensive OpenAPI/Swagger documentation for all user API endpoints using the official `@elysiajs/openapi` plugin. This allows developers to explore and test the API directly from a browser-based UI.

## Changes

### 1. Dependencies
- Added `@elysiajs/openapi` (v1.4.15) to replace deprecated `@elysiajs/swagger`

### 2. OpenAPI Plugin Configuration (`src/index.ts`)
- Imported and registered OpenAPI plugin before routes
- Configured API metadata (title, version, description)
- Defined Bearer token authentication scheme for security

### 3. Route Documentation (`src/routes/users-route.ts`)
- Added `tags: ['Users']` to group all endpoints under "Users" category
- Added `detail.summary` for each endpoint describing its purpose
- Added `detail.responses` with real examples for all endpoints:
  - **POST /api/users**: Success (200), Email conflict (409), Validation error (422)
  - **POST /api/users/login**: Token response (200), Invalid credentials (401), Validation error (422)
  - **GET /api/users/current**: User data (200), Unauthorized (401)
  - **DELETE /api/users/logout**: Success (200), Unauthorized (401)
  - **GET /api/users**: Users list example (200)

### 4. Security Documentation
- Added `security: [{ bearerAuth: [] }]` to protected endpoints (current & logout)
- Bearer token scheme configured for API

## Benefits

✅ Developer-friendly API exploration: Test endpoints directly from browser
✅ Complete response examples: See expected JSON structure for all scenarios
✅ Authentication testing: Built-in "Authorize" button for Bearer token input
✅ Auto-generated docs: Keeps documentation in sync with code
✅ No breaking changes: All existing functionality remains intact (35 tests pass)

## Access Points

- **Swagger UI**: http://localhost:3000/openapi
- **OpenAPI JSON Spec**: http://localhost:3000/openapi/json

## Definition of Done

- [x] OpenAPI plugin installed and configured
- [x] All 5 user endpoints documented with response examples
- [x] Authentication scheme properly documented
- [x] Endpoints grouped under 'Users' tag
- [x] All existing tests pass (35/35)
- [x] API documentation accessible at /openapi
- [x] Realistic example responses match actual API behavior

## Test Plan

- [x] Run `bun test` - all 35 tests pass
- [x] Verify OpenAPI JSON spec generation
- [x] Confirm swagger UI loads at /openapi
- [x] Validate response examples match actual API responses
